### PR TITLE
Fix uninitialized constant error

### DIFF
--- a/lib/fastlane/plugin/flint/actions/flint_change_password.rb
+++ b/lib/fastlane/plugin/flint/actions/flint_change_password.rb
@@ -1,5 +1,6 @@
 require 'fastlane/action'
 require_relative '../helper/flint_helper'
+require_relative 'flint_action'
 
 module Fastlane
     module Actions

--- a/lib/fastlane/plugin/flint/actions/flint_nuke.rb
+++ b/lib/fastlane/plugin/flint/actions/flint_nuke.rb
@@ -1,5 +1,6 @@
 require 'fastlane/action'
 require_relative '../helper/flint_helper'
+require_relative 'flint_action'
 
 module Fastlane
     module Actions

--- a/lib/fastlane/plugin/flint/actions/flint_setup.rb
+++ b/lib/fastlane/plugin/flint/actions/flint_setup.rb
@@ -1,6 +1,7 @@
 require 'fastlane/action'
 require_relative '../helper/git_helper'
 require_relative '../helper/encrypt'
+require_relative 'flint_action'
 
 module Fastlane
     module Actions


### PR DESCRIPTION
Added `require_relative 'flint_action'` to fix an unitialized constant error:

```
[✔] 🚀
[17:14:16]: Error loading plugin 'fastlane-plugin-flint': uninitialized constant Fastlane::Actions::FlintAction
Did you mean?  Fastlane::Actions::PilotAction                                                                                                                                                                                                       
+-------------------------+---------+------------------+
|                     Used plugins                     |
+-------------------------+---------+------------------+
| Plugin                  | Version | Action           |
+-------------------------+---------+------------------+
| fastlane-plugin-cordova | 2.2.1   | cordova          |
| fastlane-plugin-flint   | 0.1.0   | No actions found |
+-------------------------+---------+------------------+
```